### PR TITLE
Fix telegram markdown formatting and explore todo lists

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -650,8 +650,8 @@ Just send me a file and I'll handle the rest! 🚀
             )
 
             if summary:
-                # Send summary as formatted message
-                summary_message = f"📋 **Summary & Action Points**\n\n{summary}"
+                # Send summary as formatted message (Telegram classic Markdown uses single * for bold)
+                summary_message = f"📋 *Summary & Action Points*\n\n{summary}"
 
                 # Split long messages if needed
                 if len(summary_message) <= 4096:
@@ -681,7 +681,7 @@ Just send me a file and I'll handle the rest! 🚀
                             else:
                                 await context.bot.send_message(
                                     chat_id=update.effective_chat.id,
-                                    text=f"📋 **Summary & Action Points (Part {i+1})**\n\n{chunk}",
+                                    text=f"📋 *Summary & Action Points (Part {i+1})*\n\n{chunk}",
                                     parse_mode="Markdown",
                                 )
                         except Exception as e:

--- a/telegram_bot/services/summarization_service.py
+++ b/telegram_bot/services/summarization_service.py
@@ -65,6 +65,10 @@ class SummarizationService:
         # Fix unmatched inline code
         text = re.sub(r'`([^`\n]*?)(?=\n|$)', r'`\1`', text)  # Close unclosed inline code
         
+        # Convert double-asterisk bold (**text**) to single-asterisk (*text*)
+        # to align with Telegram's classic Markdown parser
+        text = re.sub(r"\*\*([^\n*]+)\*\*", r"*\\1*", text)
+
         # Remove any remaining problematic characters that could break parsing
         text = re.sub(r'[^\w\s\n\r\*_`#\-\.\!\?\(\)\[\]:\|]', '', text)
         


### PR DESCRIPTION
Enable Markdown formatting for Telegram messages and captions by setting `parse_mode` and normalizing summary formatting.

Telegram messages were sent without `parse_mode` in the backend, causing Markdown to render as plain text. Additionally, summaries used MarkdownV2-style bold (`**text**`), which is incompatible with Telegram's classic Markdown (`*text*`) that was intended to be used. This PR fixes both by explicitly setting `parse_mode="Markdown"` in all relevant API calls, adding a robust fallback for parsing errors, and converting double-asterisk bold to single-asterisk bold in summaries.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e22ba1d-cb63-451a-9d74-a2fe883b1a55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e22ba1d-cb63-451a-9d74-a2fe883b1a55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

