### PR TITLE
feat: Bridge forwarding for Zoom transcripts

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -28,6 +28,13 @@ from telegram_bot.services import (
 )
 from telegram_bot.mtproto_downloader import MTProtoDownloader
 from analytics import analytics, tg_distinct_id
+from zoom_backend.db import (
+    get_conn,
+    upsert_user,
+    get_connection_by_user_id,
+    set_bridge_chat_id,
+    get_bridge_chat_id,
+)
 
 
 class TelegramTranscriptionBot:
@@ -192,6 +199,89 @@ Just send me any video or audio file and I'll transcribe it for you!
             analytics.capture(tg_distinct_id(user.id), "command_disconnect_zoom")
         except Exception:
             pass
+
+    async def bridge_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle /bridge command — show status, enable or disable bridge forwarding."""
+        settings = get_settings()
+        user = update.effective_user
+        chat_id = update.effective_chat.id
+        distinct_id = tg_distinct_id(user.id)
+
+        try:
+            self._identify_telegram_user(user)
+        except Exception:
+            pass
+
+        # Look up the user's zoom connection
+        with get_conn(settings.zoom_db_path) as conn:
+            user_id = upsert_user(conn, user.id, chat_id)
+            zc = get_connection_by_user_id(conn, user_id)
+
+        if not zc:
+            await update.message.reply_text(
+                "❌ No Zoom account connected.\n\n"
+                "Use /connect to link your Zoom account first, then you can enable bridge forwarding.",
+            )
+            return
+
+        zoom_user_id = zc["zoom_user_id"]
+        arg = context.args[0].lower() if context.args else None
+
+        if arg == "on":
+            with get_conn(settings.zoom_db_path) as conn:
+                set_bridge_chat_id(conn, zoom_user_id, chat_id)
+            await update.message.reply_text(
+                f"✅ **Bridge enabled**\n\n"
+                f"Zoom transcripts will be forwarded to this chat (`{chat_id}`).\n"
+                f"Use `/bridge off` to disable.",
+                parse_mode="Markdown",
+            )
+            try:
+                analytics.capture(distinct_id, "bridge_enabled", {"bridge_chat_id": chat_id})
+            except Exception:
+                pass
+
+        elif arg == "off":
+            with get_conn(settings.zoom_db_path) as conn:
+                set_bridge_chat_id(conn, zoom_user_id, None)
+            await update.message.reply_text(
+                "❌ **Bridge disabled**\n\n"
+                "Zoom transcripts will no longer be forwarded.\n"
+                "Use `/bridge on` to re-enable.",
+                parse_mode="Markdown",
+            )
+            try:
+                analytics.capture(distinct_id, "bridge_disabled")
+            except Exception:
+                pass
+
+        else:
+            # Show status
+            with get_conn(settings.zoom_db_path) as conn:
+                current_bridge = get_bridge_chat_id(conn, zoom_user_id)
+
+            if current_bridge:
+                status_text = (
+                    f"🔗 **Bridge Status: ON**\n\n"
+                    f"Forwarding to chat: `{current_bridge}`\n"
+                    f"Zoom account: {zc['email'] or zoom_user_id}\n\n"
+                    f"Commands:\n"
+                    f"• `/bridge off` — disable forwarding\n"
+                    f"• `/bridge on` — re-enable (updates to current chat)"
+                )
+            else:
+                status_text = (
+                    f"🔗 **Bridge Status: OFF**\n\n"
+                    f"Zoom account: {zc['email'] or zoom_user_id}\n\n"
+                    f"Commands:\n"
+                    f"• `/bridge on` — enable forwarding to this chat\n"
+                    f"• `/bridge off` — disable forwarding"
+                )
+            await update.message.reply_text(status_text, parse_mode="Markdown")
+            try:
+                analytics.capture(distinct_id, "bridge_status_checked", {"bridge_active": bool(current_bridge)})
+            except Exception:
+                pass
 
     async def memory_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Toggle RAG indexing (semantic memory) for this user."""
@@ -1284,6 +1374,7 @@ Just send me a file and I'll handle everything automatically!
         application.add_handler(CommandHandler("connect", self.connect_command))
         application.add_handler(CommandHandler("status", self.status_command))
         application.add_handler(CommandHandler("disconnect", self.disconnect_command))
+        application.add_handler(CommandHandler("bridge", self.bridge_command))
 
         # File handlers (documents, audio, video, voice, video notes)
         application.add_handler(MessageHandler(filters.Document.ALL, self.handle_file))

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -260,11 +260,14 @@ Just send me any video or audio file and I'll transcribe it for you!
             with get_conn(settings.zoom_db_path) as conn:
                 current_bridge = get_bridge_chat_id(conn, zoom_user_id)
 
+            # Legacy Markdown: escape dynamic values so emails like a_b@x.com don't break parsing.
+            account_label = self._escape_legacy_markdown(zc["email"] or zoom_user_id)
+
             if current_bridge:
                 status_text = (
                     f"🔗 *Bridge Status: ON*\n\n"
                     f"Forwarding to chat: `{current_bridge}`\n"
-                    f"Zoom account: {zc['email'] or zoom_user_id}\n\n"
+                    f"Zoom account: {account_label}\n\n"
                     f"Commands:\n"
                     f"• `/bridge off` — disable forwarding\n"
                     f"• `/bridge on` — re-enable (updates to current chat)"
@@ -272,7 +275,7 @@ Just send me any video or audio file and I'll transcribe it for you!
             else:
                 status_text = (
                     f"🔗 *Bridge Status: OFF*\n\n"
-                    f"Zoom account: {zc['email'] or zoom_user_id}\n\n"
+                    f"Zoom account: {account_label}\n\n"
                     f"Commands:\n"
                     f"• `/bridge on` — enable forwarding to this chat\n"
                     f"• `/bridge off` — disable forwarding"
@@ -1321,6 +1324,15 @@ Just send me a file and I'll handle everything automatically!
         special_chars = ['_', '*', '[', ']', '(', ')', '~', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!']
         for char in special_chars:
             text = text.replace(char, f'\\{char}')
+        return text
+
+    def _escape_legacy_markdown(self, text: str) -> str:
+        """Escape characters that break Telegram legacy Markdown (parse_mode=Markdown)."""
+        if not text:
+            return text
+        # Backslash first so later escapes aren't double-processed incorrectly.
+        for char in ("\\", "_", "*", "`", "["):
+            text = text.replace(char, f"\\{char}")
         return text
 
     def _split_message(self, message: str, max_length: int) -> list[str]:

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -31,7 +31,7 @@ from analytics import analytics, tg_distinct_id
 from zoom_backend.db import (
     get_conn,
     upsert_user,
-    get_connection_by_user_id,
+    get_connection_by_telegram_user_id,
     set_bridge_chat_id,
     get_bridge_chat_id,
 )
@@ -214,8 +214,8 @@ Just send me any video or audio file and I'll transcribe it for you!
 
         # Look up the user's zoom connection
         with get_conn(settings.zoom_db_path) as conn:
-            user_id = upsert_user(conn, user.id, chat_id)
-            zc = get_connection_by_user_id(conn, user_id)
+            upsert_user(conn, user.id, chat_id)
+            zc = get_connection_by_telegram_user_id(conn, user.id)
 
         if not zc:
             await update.message.reply_text(
@@ -231,7 +231,7 @@ Just send me any video or audio file and I'll transcribe it for you!
             with get_conn(settings.zoom_db_path) as conn:
                 set_bridge_chat_id(conn, zoom_user_id, chat_id)
             await update.message.reply_text(
-                f"✅ **Bridge enabled**\n\n"
+                f"✅ *Bridge enabled*\n\n"
                 f"Zoom transcripts will be forwarded to this chat (`{chat_id}`).\n"
                 f"Use `/bridge off` to disable.",
                 parse_mode="Markdown",
@@ -245,7 +245,7 @@ Just send me any video or audio file and I'll transcribe it for you!
             with get_conn(settings.zoom_db_path) as conn:
                 set_bridge_chat_id(conn, zoom_user_id, None)
             await update.message.reply_text(
-                "❌ **Bridge disabled**\n\n"
+                "❌ *Bridge disabled*\n\n"
                 "Zoom transcripts will no longer be forwarded.\n"
                 "Use `/bridge on` to re-enable.",
                 parse_mode="Markdown",
@@ -262,7 +262,7 @@ Just send me any video or audio file and I'll transcribe it for you!
 
             if current_bridge:
                 status_text = (
-                    f"🔗 **Bridge Status: ON**\n\n"
+                    f"🔗 *Bridge Status: ON*\n\n"
                     f"Forwarding to chat: `{current_bridge}`\n"
                     f"Zoom account: {zc['email'] or zoom_user_id}\n\n"
                     f"Commands:\n"
@@ -271,7 +271,7 @@ Just send me any video or audio file and I'll transcribe it for you!
                 )
             else:
                 status_text = (
-                    f"🔗 **Bridge Status: OFF**\n\n"
+                    f"🔗 *Bridge Status: OFF*\n\n"
                     f"Zoom account: {zc['email'] or zoom_user_id}\n\n"
                     f"Commands:\n"
                     f"• `/bridge on` — enable forwarding to this chat\n"

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -32,6 +32,12 @@ class Settings(BaseSettings):
     deepgram_timeout_seconds: int = Field(
         default=3600, alias="DEEPGRAM_TIMEOUT_SECONDS"
     )
+    download_stall_timeout_seconds: int = Field(
+        default=180, alias="DOWNLOAD_STALL_TIMEOUT_SECONDS"
+    )
+    download_watchdog_interval_seconds: int = Field(
+        default=10, alias="DOWNLOAD_WATCHDOG_INTERVAL_SECONDS"
+    )
     
     enable_diarization: bool = Field(default=True, alias="ENABLE_DIARIZATION")
     enable_punctuation: bool = Field(default=True, alias="ENABLE_PUNCTUATION")

--- a/telegram_bot/mtproto_downloader.py
+++ b/telegram_bot/mtproto_downloader.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import tempfile
+import time
 from typing import Optional
 from pathlib import Path
 
@@ -12,6 +13,10 @@ from telethon import TelegramClient
 from telethon.tl.types import Document, DocumentAttributeFilename
 
 from telegram_bot.config import get_settings
+
+
+class DownloadStalledError(TimeoutError):
+    """Raised when a Telegram file download stops making progress."""
 
 
 class MTProtoDownloader:
@@ -49,6 +54,66 @@ class MTProtoDownloader:
         """Check if we can download a large file via MTProto."""
         # Telegram's actual file size limit is 2GB
         return file_size_mb <= 2048
+
+    async def _download_media_with_watchdog(
+        self,
+        message,
+        temp_file_path: str,
+        progress_callback=None,
+    ) -> None:
+        """Download media and cancel it if byte progress stalls."""
+        stall_timeout = max(1, self.settings.download_stall_timeout_seconds)
+        watchdog_interval = max(
+            1,
+            min(self.settings.download_watchdog_interval_seconds, stall_timeout),
+        )
+        last_progress_at = time.monotonic()
+        last_progress_bytes = 0
+
+        async def progress_hook(current: int, total: int):
+            nonlocal last_progress_at, last_progress_bytes
+            if current > last_progress_bytes:
+                last_progress_at = time.monotonic()
+                last_progress_bytes = current
+            if progress_callback:
+                await progress_callback(current, total)
+
+        download_task = asyncio.create_task(
+            self.client.download_media(
+                message,
+                file=temp_file_path,
+                progress_callback=progress_hook,
+            )
+        )
+
+        async def watchdog() -> None:
+            while not download_task.done():
+                await asyncio.sleep(watchdog_interval)
+                idle_seconds = time.monotonic() - last_progress_at
+                if idle_seconds >= stall_timeout:
+                    download_task.cancel()
+                    raise DownloadStalledError(
+                        f"Download stalled for {idle_seconds:.0f}s at "
+                        f"{last_progress_bytes} bytes"
+                    )
+
+        watchdog_task = asyncio.create_task(watchdog())
+
+        done, pending = await asyncio.wait(
+            {download_task, watchdog_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+        if watchdog_task in done:
+            # Propagate DownloadStalledError if the watchdog stopped the download.
+            await watchdog_task
+
+        await download_task
 
     async def download_large_file(
         self,
@@ -175,21 +240,20 @@ class MTProtoDownloader:
 
             logger.info(f"Starting MTProto download: {file_name} ({file_size / (1024*1024):.1f}MB)")
 
-            # Progress tracking
-            async def progress_hook(current: int, total: int):
-                if progress_callback:
-                    await progress_callback(current, total)
-
-            # Download the file
-            await self.client.download_media(
+            await self._download_media_with_watchdog(
                 message,
-                file=temp_file_path,
-                progress_callback=progress_hook
+                temp_file_path,
+                progress_callback,
             )
 
             logger.info(f"Successfully downloaded large file: {temp_file_path}")
             return temp_file_path
 
+        except DownloadStalledError as e:
+            logger.error(f"Download stalled via MTProto: {e}")
+            if 'temp_file_path' in locals() and os.path.exists(temp_file_path):
+                os.remove(temp_file_path)
+            return None
         except Exception as e:
             logger.error(f"Error downloading file via MTProto: {e}")
             if 'temp_file_path' in locals() and os.path.exists(temp_file_path):

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -14,6 +14,7 @@ from zoom_backend.db import (
     save_connection,
     set_bridge_chat_id,
     get_bridge_chat_id,
+    get_connection_by_telegram_user_id,
     get_connection_by_user_id,
 )
 
@@ -133,6 +134,18 @@ class TestBridgeDbHelpers:
         finally:
             os.unlink(path)
 
+    def test_get_connection_by_telegram_user_id_across_chats(self):
+        path = _make_db()
+        try:
+            zoom_user_id = _seed_connection(path, telegram_user_id=111, chat_id=100)
+            with get_conn(path) as conn:
+                upsert_user(conn, 111, 200)
+                row = get_connection_by_telegram_user_id(conn, 111)
+            assert row is not None
+            assert row["zoom_user_id"] == zoom_user_id
+        finally:
+            os.unlink(path)
+
 
 # ---------------------------------------------------------------------------
 # 3. /bridge command tests
@@ -200,6 +213,26 @@ class TestBridgeCommand:
             os.unlink(path)
 
     @pytest.mark.asyncio
+    async def test_bridge_on_uses_connection_from_different_chat(self):
+        path = _make_db()
+        try:
+            _seed_connection(path, telegram_user_id=111, chat_id=100)
+            update = _make_update(user_id=111, chat_id=200)
+            ctx = _make_context(args=["on"])
+            with patch.dict(os.environ, {**ENV_VARS, "ZOOM_DB_PATH": path}):
+                from telegram_bot.bot import TelegramTranscriptionBot
+                bot = TelegramTranscriptionBot()
+                await bot.bridge_command(update, ctx)
+            text = update.message.reply_text.call_args[0][0]
+            assert "No Zoom account connected" not in text
+            assert "Bridge enabled" in text
+
+            with get_conn(path) as conn:
+                assert get_bridge_chat_id(conn, "zoom_abc123") == 200
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
     async def test_bridge_off(self):
         path = _make_db()
         try:
@@ -218,6 +251,38 @@ class TestBridgeCommand:
 
             with get_conn(path) as conn:
                 assert get_bridge_chat_id(conn, zoom_user_id) is None
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("args", "bridge_chat_id"),
+        [
+            (["on"], None),
+            (["off"], 222),
+            ([], 222),
+            ([], None),
+        ],
+    )
+    async def test_bridge_replies_use_legacy_markdown_bold(self, args, bridge_chat_id):
+        path = _make_db()
+        try:
+            zoom_user_id = _seed_connection(path)
+            if bridge_chat_id is not None:
+                with get_conn(path) as conn:
+                    set_bridge_chat_id(conn, zoom_user_id, bridge_chat_id)
+
+            update = _make_update()
+            ctx = _make_context(args=args)
+            with patch.dict(os.environ, {**ENV_VARS, "ZOOM_DB_PATH": path}):
+                from telegram_bot.bot import TelegramTranscriptionBot
+                bot = TelegramTranscriptionBot()
+                await bot.bridge_command(update, ctx)
+
+            text = update.message.reply_text.call_args[0][0]
+            assert "**" not in text
+            assert "*" in text
+            assert update.message.reply_text.call_args.kwargs["parse_mode"] == "Markdown"
         finally:
             os.unlink(path)
 

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,0 +1,389 @@
+"""Tests for the bridge feature — DB migration, /bridge command, forward_to_bridge."""
+
+import os
+import sqlite3
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from zoom_backend.db import (
+    ensure_db,
+    get_conn,
+    upsert_user,
+    save_connection,
+    set_bridge_chat_id,
+    get_bridge_chat_id,
+    get_connection_by_user_id,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_db() -> str:
+    """Create a temporary DB and return its path."""
+    fd, path = tempfile.mkstemp(suffix=".sqlite3")
+    os.close(fd)
+    ensure_db(path)
+    return path
+
+
+def _seed_connection(path: str, telegram_user_id: int = 111, chat_id: int = 222) -> str:
+    """Insert a user + zoom connection and return zoom_user_id."""
+    zoom_user_id = "zoom_abc123"
+    with get_conn(path) as conn:
+        user_id = upsert_user(conn, telegram_user_id, chat_id)
+        save_connection(
+            conn,
+            zoom_user_id,
+            user_id,
+            {"access_token": "at", "refresh_token": "rt", "expires_in": 3600},
+            email="user@example.com",
+        )
+    return zoom_user_id
+
+
+# ---------------------------------------------------------------------------
+# 1. DB Migration Tests
+# ---------------------------------------------------------------------------
+
+class TestBridgeMigration:
+    def test_bridge_chat_id_column_exists_after_ensure_db(self):
+        path = _make_db()
+        try:
+            with get_conn(path) as conn:
+                cur = conn.execute("PRAGMA table_info(zoom_connections)")
+                columns = {row["name"] for row in cur.fetchall()}
+            assert "bridge_chat_id" in columns
+        finally:
+            os.unlink(path)
+
+    def test_migration_is_idempotent(self):
+        """Calling ensure_db twice should not fail."""
+        path = _make_db()
+        try:
+            ensure_db(path)  # second call
+            with get_conn(path) as conn:
+                cur = conn.execute("PRAGMA table_info(zoom_connections)")
+                columns = [row["name"] for row in cur.fetchall()]
+            assert columns.count("bridge_chat_id") == 1
+        finally:
+            os.unlink(path)
+
+    def test_bridge_chat_id_defaults_to_null(self):
+        path = _make_db()
+        try:
+            zoom_user_id = _seed_connection(path)
+            with get_conn(path) as conn:
+                result = get_bridge_chat_id(conn, zoom_user_id)
+            assert result is None
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# 2. DB helper function tests
+# ---------------------------------------------------------------------------
+
+class TestBridgeDbHelpers:
+    def test_set_and_get_bridge_chat_id(self):
+        path = _make_db()
+        try:
+            zoom_user_id = _seed_connection(path)
+            with get_conn(path) as conn:
+                set_bridge_chat_id(conn, zoom_user_id, 999)
+            with get_conn(path) as conn:
+                assert get_bridge_chat_id(conn, zoom_user_id) == 999
+        finally:
+            os.unlink(path)
+
+    def test_clear_bridge_chat_id(self):
+        path = _make_db()
+        try:
+            zoom_user_id = _seed_connection(path)
+            with get_conn(path) as conn:
+                set_bridge_chat_id(conn, zoom_user_id, 999)
+            with get_conn(path) as conn:
+                set_bridge_chat_id(conn, zoom_user_id, None)
+            with get_conn(path) as conn:
+                assert get_bridge_chat_id(conn, zoom_user_id) is None
+        finally:
+            os.unlink(path)
+
+    def test_get_connection_by_user_id(self):
+        path = _make_db()
+        try:
+            zoom_user_id = _seed_connection(path)
+            with get_conn(path) as conn:
+                user_id = upsert_user(conn, 111, 222)
+                row = get_connection_by_user_id(conn, user_id)
+            assert row is not None
+            assert row["zoom_user_id"] == zoom_user_id
+        finally:
+            os.unlink(path)
+
+    def test_get_connection_by_user_id_not_found(self):
+        path = _make_db()
+        try:
+            with get_conn(path) as conn:
+                row = get_connection_by_user_id(conn, 99999)
+            assert row is None
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# 3. /bridge command tests
+# ---------------------------------------------------------------------------
+
+ENV_VARS = {
+    "TELEGRAM_BOT_TOKEN": "test_token",
+    "TELEGRAM_API_ID": "123456",
+    "TELEGRAM_API_HASH": "test_hash",
+    "DEEPGRAM_API_KEY": "test_deepgram",
+    "GOOGLE_API_KEY": "test_google",
+}
+
+
+def _make_update(user_id: int = 111, chat_id: int = 222):
+    """Build a minimal mock Update + context."""
+    update = MagicMock()
+    update.effective_user.id = user_id
+    update.effective_chat.id = chat_id
+    update.message.reply_text = AsyncMock()
+    return update
+
+
+def _make_context(args=None):
+    ctx = MagicMock()
+    ctx.args = args or []
+    return ctx
+
+
+class TestBridgeCommand:
+    @pytest.mark.asyncio
+    async def test_bridge_no_zoom_connection(self):
+        path = _make_db()
+        try:
+            update = _make_update()
+            ctx = _make_context()
+            with patch.dict(os.environ, {**ENV_VARS, "ZOOM_DB_PATH": path}):
+                from telegram_bot.bot import TelegramTranscriptionBot
+                bot = TelegramTranscriptionBot()
+                await bot.bridge_command(update, ctx)
+            update.message.reply_text.assert_awaited_once()
+            text = update.message.reply_text.call_args[0][0]
+            assert "No Zoom account connected" in text
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_bridge_on(self):
+        path = _make_db()
+        try:
+            _seed_connection(path)
+            update = _make_update()
+            ctx = _make_context(args=["on"])
+            with patch.dict(os.environ, {**ENV_VARS, "ZOOM_DB_PATH": path}):
+                from telegram_bot.bot import TelegramTranscriptionBot
+                bot = TelegramTranscriptionBot()
+                await bot.bridge_command(update, ctx)
+            text = update.message.reply_text.call_args[0][0]
+            assert "Bridge enabled" in text
+
+            # Verify DB
+            with get_conn(path) as conn:
+                assert get_bridge_chat_id(conn, "zoom_abc123") == 222
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_bridge_off(self):
+        path = _make_db()
+        try:
+            zoom_user_id = _seed_connection(path)
+            with get_conn(path) as conn:
+                set_bridge_chat_id(conn, zoom_user_id, 222)
+
+            update = _make_update()
+            ctx = _make_context(args=["off"])
+            with patch.dict(os.environ, {**ENV_VARS, "ZOOM_DB_PATH": path}):
+                from telegram_bot.bot import TelegramTranscriptionBot
+                bot = TelegramTranscriptionBot()
+                await bot.bridge_command(update, ctx)
+            text = update.message.reply_text.call_args[0][0]
+            assert "Bridge disabled" in text
+
+            with get_conn(path) as conn:
+                assert get_bridge_chat_id(conn, zoom_user_id) is None
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_bridge_status_on(self):
+        path = _make_db()
+        try:
+            zoom_user_id = _seed_connection(path)
+            with get_conn(path) as conn:
+                set_bridge_chat_id(conn, zoom_user_id, 222)
+
+            update = _make_update()
+            ctx = _make_context()
+            with patch.dict(os.environ, {**ENV_VARS, "ZOOM_DB_PATH": path}):
+                from telegram_bot.bot import TelegramTranscriptionBot
+                bot = TelegramTranscriptionBot()
+                await bot.bridge_command(update, ctx)
+            text = update.message.reply_text.call_args[0][0]
+            assert "Status: ON" in text
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_bridge_status_off(self):
+        path = _make_db()
+        try:
+            _seed_connection(path)
+            update = _make_update()
+            ctx = _make_context()
+            with patch.dict(os.environ, {**ENV_VARS, "ZOOM_DB_PATH": path}):
+                from telegram_bot.bot import TelegramTranscriptionBot
+                bot = TelegramTranscriptionBot()
+                await bot.bridge_command(update, ctx)
+            text = update.message.reply_text.call_args[0][0]
+            assert "Status: OFF" in text
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# 4. forward_to_bridge() tests
+# ---------------------------------------------------------------------------
+
+class TestForwardToBridge:
+    @pytest.mark.asyncio
+    async def test_forward_to_bridge_skips_when_no_bridge(self):
+        """When no bridge_chat_id is set, nothing should be sent."""
+        path = _make_db()
+        try:
+            _seed_connection(path)
+            with patch.dict(os.environ, {**ENV_VARS, "ZOOM_DB_PATH": path}):
+                from zoom_backend.app import forward_to_bridge, send_message
+                with patch("zoom_backend.app.send_message", new_callable=AsyncMock) as mock_send:
+                    await forward_to_bridge(
+                        zoom_user_id="zoom_abc123",
+                        topic="Test Meeting",
+                        transcript_with_date="Hello world",
+                        summary="Summary text",
+                        recording_date="February 5, 2026 at 10:00",
+                        meeting_uuid="uuid-1234-5678",
+                        participants=["Alice", "Bob"],
+                    )
+                    mock_send.assert_not_awaited()
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_forward_to_bridge_sends_when_configured(self):
+        """When bridge_chat_id is set, should send header + document + summary."""
+        path = _make_db()
+        try:
+            zoom_user_id = _seed_connection(path)
+            with get_conn(path) as conn:
+                set_bridge_chat_id(conn, zoom_user_id, 999)
+
+            with patch.dict(os.environ, {**ENV_VARS, "ZOOM_DB_PATH": path}):
+                with patch("zoom_backend.app.send_message", new_callable=AsyncMock) as mock_send, \
+                     patch("zoom_backend.app.send_telegram_document", new_callable=AsyncMock) as mock_doc, \
+                     patch("zoom_backend.app.send_long_message", new_callable=AsyncMock) as mock_long:
+                    # Mock FileService.create_text_file
+                    with patch("zoom_backend.app.FileService") as MockFS:
+                        mock_fs_instance = MockFS.return_value
+                        mock_fs_instance.create_text_file = AsyncMock(return_value="/tmp/test.txt")
+
+                        from zoom_backend.app import forward_to_bridge
+                        await forward_to_bridge(
+                            zoom_user_id="zoom_abc123",
+                            topic="Sprint Planning",
+                            transcript_with_date="Recording Date: Feb 5\n\nAlice: Hi\nBob: Hello",
+                            summary="Key decisions were made.",
+                            recording_date="February 5, 2026 at 10:00",
+                            meeting_uuid="uuid-1234-5678-abcd-ef",
+                            participants=["Alice", "Bob"],
+                        )
+
+                    # Header message
+                    mock_send.assert_awaited_once()
+                    header_text = mock_send.call_args[0][1]
+                    assert "Sprint Planning" in header_text
+                    assert "Alice" in header_text
+                    assert mock_send.call_args[0][0] == 999
+
+                    # Document
+                    mock_doc.assert_awaited_once()
+                    assert mock_doc.call_args[0][0] == 999
+
+                    # Summary
+                    mock_long.assert_awaited_once()
+                    assert mock_long.call_args[0][0] == 999
+                    assert "Key decisions" in mock_long.call_args[0][1]
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_forward_to_bridge_no_summary(self):
+        """When summary is None, should not call send_long_message."""
+        path = _make_db()
+        try:
+            zoom_user_id = _seed_connection(path)
+            with get_conn(path) as conn:
+                set_bridge_chat_id(conn, zoom_user_id, 999)
+
+            with patch.dict(os.environ, {**ENV_VARS, "ZOOM_DB_PATH": path}):
+                with patch("zoom_backend.app.send_message", new_callable=AsyncMock), \
+                     patch("zoom_backend.app.send_telegram_document", new_callable=AsyncMock), \
+                     patch("zoom_backend.app.send_long_message", new_callable=AsyncMock) as mock_long:
+                    with patch("zoom_backend.app.FileService") as MockFS:
+                        mock_fs_instance = MockFS.return_value
+                        mock_fs_instance.create_text_file = AsyncMock(return_value="/tmp/test.txt")
+
+                        from zoom_backend.app import forward_to_bridge
+                        await forward_to_bridge(
+                            zoom_user_id="zoom_abc123",
+                            topic="Standup",
+                            transcript_with_date="Hi everyone",
+                            summary=None,
+                            recording_date=None,
+                            meeting_uuid="uuid-0000",
+                            participants=[],
+                        )
+                    mock_long.assert_not_awaited()
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_forward_to_bridge_handles_error_gracefully(self):
+        """If sending fails, forward_to_bridge should not raise."""
+        path = _make_db()
+        try:
+            zoom_user_id = _seed_connection(path)
+            with get_conn(path) as conn:
+                set_bridge_chat_id(conn, zoom_user_id, 999)
+
+            with patch.dict(os.environ, {**ENV_VARS, "ZOOM_DB_PATH": path}):
+                with patch("zoom_backend.app.send_message", new_callable=AsyncMock) as mock_send:
+                    mock_send.side_effect = Exception("Telegram API error")
+                    from zoom_backend.app import forward_to_bridge
+                    # Should not raise
+                    await forward_to_bridge(
+                        zoom_user_id="zoom_abc123",
+                        topic="Broken",
+                        transcript_with_date="text",
+                        summary="sum",
+                        recording_date=None,
+                        meeting_uuid="uuid",
+                        participants=[],
+                    )
+        finally:
+            os.unlink(path)

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -452,3 +452,19 @@ class TestForwardToBridge:
                     )
         finally:
             os.unlink(path)
+
+    @pytest.mark.asyncio
+    async def test_forward_to_bridge_handles_db_error_gracefully(self):
+        """If bridge DB lookup fails, forward_to_bridge should not raise."""
+        with patch("zoom_backend.app.get_settings", side_effect=sqlite3.Error("DB error")):
+            from zoom_backend.app import forward_to_bridge
+
+            await forward_to_bridge(
+                zoom_user_id="zoom_abc123",
+                topic="Broken",
+                transcript_with_date="text",
+                summary="sum",
+                recording_date=None,
+                meeting_uuid="uuid",
+                participants=[],
+            )

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -15,7 +15,6 @@ from zoom_backend.db import (
     set_bridge_chat_id,
     get_bridge_chat_id,
     get_connection_by_telegram_user_id,
-    get_connection_by_user_id,
 )
 
 
@@ -31,7 +30,12 @@ def _make_db() -> str:
     return path
 
 
-def _seed_connection(path: str, telegram_user_id: int = 111, chat_id: int = 222) -> str:
+def _seed_connection(
+    path: str,
+    telegram_user_id: int = 111,
+    chat_id: int = 222,
+    email: str = "user@example.com",
+) -> str:
     """Insert a user + zoom connection and return zoom_user_id."""
     zoom_user_id = "zoom_abc123"
     with get_conn(path) as conn:
@@ -41,7 +45,7 @@ def _seed_connection(path: str, telegram_user_id: int = 111, chat_id: int = 222)
             zoom_user_id,
             user_id,
             {"access_token": "at", "refresh_token": "rt", "expires_in": 3600},
-            email="user@example.com",
+            email=email,
         )
     return zoom_user_id
 
@@ -110,27 +114,6 @@ class TestBridgeDbHelpers:
                 set_bridge_chat_id(conn, zoom_user_id, None)
             with get_conn(path) as conn:
                 assert get_bridge_chat_id(conn, zoom_user_id) is None
-        finally:
-            os.unlink(path)
-
-    def test_get_connection_by_user_id(self):
-        path = _make_db()
-        try:
-            zoom_user_id = _seed_connection(path)
-            with get_conn(path) as conn:
-                user_id = upsert_user(conn, 111, 222)
-                row = get_connection_by_user_id(conn, user_id)
-            assert row is not None
-            assert row["zoom_user_id"] == zoom_user_id
-        finally:
-            os.unlink(path)
-
-    def test_get_connection_by_user_id_not_found(self):
-        path = _make_db()
-        try:
-            with get_conn(path) as conn:
-                row = get_connection_by_user_id(conn, 99999)
-            assert row is None
         finally:
             os.unlink(path)
 
@@ -318,6 +301,30 @@ class TestBridgeCommand:
                 await bot.bridge_command(update, ctx)
             text = update.message.reply_text.call_args[0][0]
             assert "Status: OFF" in text
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bridge_chat_id", [222, None])
+    async def test_bridge_status_escapes_email_markdown(self, bridge_chat_id):
+        """Emails with underscores must be escaped for legacy Markdown replies."""
+        path = _make_db()
+        try:
+            zoom_user_id = _seed_connection(path, email="john_doe@example.com")
+            if bridge_chat_id is not None:
+                with get_conn(path) as conn:
+                    set_bridge_chat_id(conn, zoom_user_id, bridge_chat_id)
+
+            update = _make_update()
+            ctx = _make_context()
+            with patch.dict(os.environ, {**ENV_VARS, "ZOOM_DB_PATH": path}):
+                from telegram_bot.bot import TelegramTranscriptionBot
+                bot = TelegramTranscriptionBot()
+                await bot.bridge_command(update, ctx)
+
+            text = update.message.reply_text.call_args[0][0]
+            assert "john\\_doe@example.com" in text
+            assert update.message.reply_text.call_args.kwargs["parse_mode"] == "Markdown"
         finally:
             os.unlink(path)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,8 @@ def test_settings_default_values():
         assert settings.temp_dir == "./temp"
         assert settings.log_level == "INFO"
         assert settings.deepgram_model == "nova-2"
+        assert settings.download_stall_timeout_seconds == 180
+        assert settings.download_watchdog_interval_seconds == 10
         # Language detection is now automatic
         assert settings.enable_diarization is True
         assert settings.enable_punctuation is True

--- a/tests/test_mtproto_downloader.py
+++ b/tests/test_mtproto_downloader.py
@@ -1,0 +1,76 @@
+"""Tests for MTProto download failure handling."""
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from telegram_bot.mtproto_downloader import MTProtoDownloader
+
+
+def _env(temp_dir: str) -> dict[str, str]:
+    return {
+        "TELEGRAM_BOT_TOKEN": "test_token",
+        "TELEGRAM_API_ID": "123456",
+        "TELEGRAM_API_HASH": "test_hash",
+        "DEEPGRAM_API_KEY": "test_deepgram",
+        "GOOGLE_API_KEY": "test_google",
+        "TEMP_DIR": temp_dir,
+        "DOWNLOAD_STALL_TIMEOUT_SECONDS": "1",
+        "DOWNLOAD_WATCHDOG_INTERVAL_SECONDS": "1",
+    }
+
+
+def _message(size: int = 1024) -> SimpleNamespace:
+    return SimpleNamespace(
+        document=SimpleNamespace(
+            size=size,
+            attributes=[],
+        )
+    )
+
+
+async def test_download_file_by_message_removes_partial_file_on_stall(tmp_path):
+    """A stuck Telegram download should fail cleanly instead of hanging forever."""
+
+    class StallingClient:
+        async def get_messages(self, chat_id, ids):
+            return _message()
+
+        async def download_media(self, message, file, progress_callback):
+            with open(file, "wb") as handle:
+                handle.write(b"partial")
+            await asyncio.sleep(10)
+
+    with patch.dict(os.environ, _env(str(tmp_path)), clear=True):
+        downloader = MTProtoDownloader()
+        downloader.client = StallingClient()
+
+        result = await downloader.download_file_by_message(123, 456)
+
+    assert result is None
+    assert list(tmp_path.iterdir()) == []
+
+
+async def test_download_file_by_message_returns_path_when_download_completes(tmp_path):
+    """A healthy Telegram download should still return the completed temp file."""
+
+    class HealthyClient:
+        async def get_messages(self, chat_id, ids):
+            return _message(size=2)
+
+        async def download_media(self, message, file, progress_callback):
+            await progress_callback(1, 2)
+            with open(file, "wb") as handle:
+                handle.write(b"ok")
+            await progress_callback(2, 2)
+
+    with patch.dict(os.environ, _env(str(tmp_path)), clear=True):
+        downloader = MTProtoDownloader()
+        downloader.client = HealthyClient()
+
+        result = await downloader.download_file_by_message(123, 456)
+
+    assert result is not None
+    assert os.path.exists(result)
+    assert open(result, "rb").read() == b"ok"

--- a/zoom_backend/app.py
+++ b/zoom_backend/app.py
@@ -33,6 +33,7 @@ from zoom_backend.db import (
     upsert_meeting,
     insert_recording_if_new,
     update_tokens_by_zoom_user_id,
+    get_bridge_chat_id,
 )
 
 
@@ -701,8 +702,8 @@ async def process_recording(
                 logger.warning(f"Zoom transcript alignment failed: {e}")
 
             # Try applying Zoom participant names to the transcript before saving
+            zoom_names: list[str] = []
             if not aligned_mapping:
-                zoom_names: list[str] = []
                 try:
                     zoom_names = await fetch_meeting_participants(access_token, meeting_uuid)
                 except Exception as e:
@@ -746,6 +747,17 @@ async def process_recording(
                     analytics.capture(distinct_id, "zoom_summary_succeeded", {"chars": len(summary or "")})
                 except Exception:
                     pass
+
+            # Forward to bridge chat if configured
+            await forward_to_bridge(
+                zoom_user_id=zoom_user_id,
+                topic=data.get("topic", "Unknown"),
+                transcript_with_date=transcript_with_date,
+                summary=summary,
+                recording_date=recording_date_str,
+                meeting_uuid=meeting_uuid,
+                participants=zoom_names,
+            )
         else:
             await send_message(chat_id, "⚠️ Could not create transcript from Zoom recording.")
             try:
@@ -761,6 +773,55 @@ async def process_recording(
             analytics.capture(distinct_id, "zoom_processing_error", {"error": str(e)[:200]})
         except Exception:
             pass
+
+
+async def forward_to_bridge(
+    zoom_user_id: str,
+    topic: str,
+    transcript_with_date: str,
+    summary: Optional[str],
+    recording_date: Optional[str],
+    meeting_uuid: str,
+    participants: List[str],
+) -> None:
+    """Forward transcript + summary to bridge chat if configured for this zoom user."""
+    settings = get_settings()
+
+    with get_conn(settings.zoom_db_path) as conn:
+        bridge_chat_id = get_bridge_chat_id(conn, zoom_user_id)
+
+    if not bridge_chat_id:
+        return
+
+    logger.info("Forwarding to bridge chat {} for zoom_user {}", bridge_chat_id, zoom_user_id)
+
+    try:
+        # 1. Structured header message
+        header = "🎙 *Zoom Meeting Transcript*\n"
+        header += f"*Topic:* {topic}\n"
+        if recording_date:
+            header += f"*Date:* {recording_date}\n"
+        if participants:
+            header += f"*Participants:* {', '.join(participants)}\n"
+        header += f"*Meeting ID:* `{meeting_uuid[:12]}…`"
+
+        await send_message(bridge_chat_id, header)
+
+        # 2. Transcript as .txt file
+        file_service = FileService()
+        timestamp = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
+        safe_topic = re.sub(r"[^\w\s-]", "", topic).strip().replace(" ", "_")[:30]
+        filename = f"meeting_{timestamp}_{safe_topic}.txt"
+        transcript_path = await file_service.create_text_file(transcript_with_date, filename)
+        await send_telegram_document(bridge_chat_id, transcript_path, f"📄 Transcript: {topic}")
+
+        # 3. Summary as text message
+        if summary:
+            await send_long_message(bridge_chat_id, f"📋 *Summary*\n\n{summary}")
+
+        logger.info("Successfully forwarded to bridge chat {}", bridge_chat_id)
+    except Exception as e:
+        logger.warning("Failed to forward to bridge chat {}: {}", bridge_chat_id, e)
 
 
 async def send_telegram_audio(chat_id: int, path: str, caption: str) -> None:

--- a/zoom_backend/app.py
+++ b/zoom_backend/app.py
@@ -702,8 +702,8 @@ async def process_recording(
                 logger.warning(f"Zoom transcript alignment failed: {e}")
 
             # Try applying Zoom participant names to the transcript before saving
-            zoom_names: list[str] = []
-            if not aligned_mapping:
+            zoom_names: list[str] = list(dict.fromkeys(name for name in aligned_mapping.values() if name))
+            if not zoom_names:
                 try:
                     zoom_names = await fetch_meeting_participants(access_token, meeting_uuid)
                 except Exception as e:

--- a/zoom_backend/app.py
+++ b/zoom_backend/app.py
@@ -785,17 +785,17 @@ async def forward_to_bridge(
     participants: List[str],
 ) -> None:
     """Forward transcript + summary to bridge chat if configured for this zoom user."""
-    settings = get_settings()
-
-    with get_conn(settings.zoom_db_path) as conn:
-        bridge_chat_id = get_bridge_chat_id(conn, zoom_user_id)
-
-    if not bridge_chat_id:
-        return
-
-    logger.info("Forwarding to bridge chat {} for zoom_user {}", bridge_chat_id, zoom_user_id)
-
     try:
+        settings = get_settings()
+
+        with get_conn(settings.zoom_db_path) as conn:
+            bridge_chat_id = get_bridge_chat_id(conn, zoom_user_id)
+
+        if not bridge_chat_id:
+            return
+
+        logger.info("Forwarding to bridge chat {} for zoom_user {}", bridge_chat_id, zoom_user_id)
+
         # 1. Structured header message
         header = "🎙 *Zoom Meeting Transcript*\n"
         header += f"*Topic:* {topic}\n"
@@ -821,7 +821,7 @@ async def forward_to_bridge(
 
         logger.info("Successfully forwarded to bridge chat {}", bridge_chat_id)
     except Exception as e:
-        logger.warning("Failed to forward to bridge chat {}: {}", bridge_chat_id, e)
+        logger.warning("Failed to forward to bridge for zoom_user {}: {}", zoom_user_id, e)
 
 
 async def send_telegram_audio(chat_id: int, path: str, caption: str) -> None:

--- a/zoom_backend/db.py
+++ b/zoom_backend/db.py
@@ -288,15 +288,3 @@ def get_bridge_chat_id(conn: sqlite3.Connection, zoom_user_id: str) -> Optional[
         return int(row[0])
     return None
 
-
-def get_connection_by_user_id(
-    conn: sqlite3.Connection, user_id: int
-) -> Optional[sqlite3.Row]:
-    """Get zoom connection by internal user_id."""
-    cur = conn.execute(
-        "SELECT * FROM zoom_connections WHERE user_id = ?",
-        (user_id,),
-    )
-    return cur.fetchone()
-
-

--- a/zoom_backend/db.py
+++ b/zoom_backend/db.py
@@ -225,6 +225,23 @@ def get_connection_by_telegram(
     return cur.fetchone()
 
 
+def get_connection_by_telegram_user_id(
+    conn: sqlite3.Connection, telegram_user_id: int
+) -> Optional[sqlite3.Row]:
+    """Get zoom connection by Telegram user across chats."""
+    cur = conn.execute(
+        """
+        SELECT zc.* FROM zoom_connections zc
+        JOIN users u ON u.id = zc.user_id
+        WHERE u.telegram_user_id = ?
+        ORDER BY zc.id DESC
+        LIMIT 1
+        """,
+        (telegram_user_id,),
+    )
+    return cur.fetchone()
+
+
 def update_tokens_by_zoom_user_id(
     conn: sqlite3.Connection, zoom_user_id: str, tokens: Dict[str, Any]
 ) -> None:

--- a/zoom_backend/db.py
+++ b/zoom_backend/db.py
@@ -56,6 +56,18 @@ def ensure_db(path: str) -> None:
             )
             """
         )
+        # Migration: add bridge_chat_id column to zoom_connections if missing
+        _migrate_add_bridge_chat_id(conn)
+
+
+def _migrate_add_bridge_chat_id(conn: sqlite3.Connection) -> None:
+    """Add bridge_chat_id column to zoom_connections if it doesn't exist."""
+    cur = conn.execute("PRAGMA table_info(zoom_connections)")
+    columns = {row[1] for row in cur.fetchall()}
+    if "bridge_chat_id" not in columns:
+        conn.execute(
+            "ALTER TABLE zoom_connections ADD COLUMN bridge_chat_id INTEGER"
+        )
 
 
 @contextmanager
@@ -233,5 +245,41 @@ def update_tokens_by_zoom_user_id(
             zoom_user_id,
         ),
     )
+
+
+# --- Bridge functions ---
+
+
+def set_bridge_chat_id(
+    conn: sqlite3.Connection, zoom_user_id: str, bridge_chat_id: Optional[int]
+) -> None:
+    """Set or clear bridge_chat_id for a zoom connection."""
+    conn.execute(
+        "UPDATE zoom_connections SET bridge_chat_id = ? WHERE zoom_user_id = ?",
+        (bridge_chat_id, zoom_user_id),
+    )
+
+
+def get_bridge_chat_id(conn: sqlite3.Connection, zoom_user_id: str) -> Optional[int]:
+    """Get bridge_chat_id for a zoom connection. Returns None if not set."""
+    cur = conn.execute(
+        "SELECT bridge_chat_id FROM zoom_connections WHERE zoom_user_id = ?",
+        (zoom_user_id,),
+    )
+    row = cur.fetchone()
+    if row and row[0] is not None:
+        return int(row[0])
+    return None
+
+
+def get_connection_by_user_id(
+    conn: sqlite3.Connection, user_id: int
+) -> Optional[sqlite3.Row]:
+    """Get zoom connection by internal user_id."""
+    cur = conn.execute(
+        "SELECT * FROM zoom_connections WHERE user_id = ?",
+        (user_id,),
+    )
+    return cur.fetchone()
 
 


### PR DESCRIPTION
## What

Per-connection bridge forwarding: each user can `/bridge on` to forward Zoom transcripts to a designated Telegram chat (e.g. Luna/OpenClaw integration).

## Changes

### 1. DB Migration (`zoom_backend/db.py`)
- Added `bridge_chat_id` nullable integer column to `zoom_connections`
- Auto-migration on startup via `ensure_db()` — checks PRAGMA and ALTERs if missing
- New helpers: `set_bridge_chat_id()`, `get_bridge_chat_id()`, `get_connection_by_user_id()`

### 2. Bot Command (`telegram_bot/bot.py`)
- `/bridge` — shows current bridge status (on/off, target chat)
- `/bridge on` — enables bridge, saves current chat_id as bridge target
- `/bridge off` — disables bridge (sets bridge_chat_id = NULL)
- Per-connection: each user controls their own Zoom account's bridge

### 3. Forward Logic (`zoom_backend/app.py`)
- `forward_to_bridge()` function called after transcript + summary are sent to user
- Sends to bridge chat:
  1. Structured header (topic, date, participants, meeting UUID)
  2. Transcript as `.txt` file
  3. Summary as text message
- Graceful error handling — bridge failure doesn't break main flow

### 4. Tests (`tests/test_bridge.py`)
- 16 unit tests covering:
  - DB migration (column exists, idempotent, defaults to NULL)
  - DB helpers (set/get/clear bridge_chat_id)
  - `/bridge` command (no connection, on, off, status on, status off)
  - `forward_to_bridge()` (skip when no bridge, send when configured, no summary, error handling)

All tests pass ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Forwards full meeting transcripts and summaries to user-selected chats (data exposure if misconfigured), and changes Zoom post-processing plus large-file download behavior; bridge errors are isolated from the primary user flow.
> 
> **Overview**
> Adds **per-user Zoom→Telegram bridge forwarding**: users with a linked Zoom account can run `/bridge on|off` (or view status) to store a `bridge_chat_id` on their connection. After normal post-meeting delivery, **`forward_to_bridge`** optionally sends a header, transcript `.txt`, and summary to that chat; failures are logged and do not block the main flow.
> 
> **Persistence:** `zoom_connections.bridge_chat_id` is added via an idempotent `ensure_db` migration, with `set_bridge_chat_id`, `get_bridge_chat_id`, and **`get_connection_by_telegram_user_id`** so `/bridge` works even when the command is run from a different chat than where Zoom was connected. Bridge status replies use legacy Markdown escaping for dynamic fields (e.g. emails with underscores).
> 
> **Related fixes:** Zoom processing reuses speaker names from alignment when building participant lists for bridge headers; large Telegram downloads use a **stall watchdog** (configurable `DOWNLOAD_STALL_TIMEOUT_SECONDS` / `DOWNLOAD_WATCHDOG_INTERVAL_SECONDS`) that cancels hung MTProto downloads and removes partial temp files.
> 
> Coverage includes new tests for bridge DB/command/forwarding and MTProto stall handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9fad6c38464caf36fb2ef98314bdd995ba301ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->